### PR TITLE
ttlSecondsAfterFinished til en halv time

### DIFF
--- a/arcgis-cronjobs/templates/cronjob.yaml
+++ b/arcgis-cronjobs/templates/cronjob.yaml
@@ -23,7 +23,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 0
-      ttlSecondsAfterFinished: 36000
+      ttlSecondsAfterFinished: 1800
       template:
         spec:
           securityContext:

--- a/arcgis-cronjobs/templates/cronjob.yaml
+++ b/arcgis-cronjobs/templates/cronjob.yaml
@@ -23,6 +23,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 0
+      ttlSecondsAfterFinished: 36000
       template:
         spec:
           securityContext:


### PR DESCRIPTION
Ikke nødvendig å beholde feilede jobber lenger enn til neste schedulerte jobb starter. Dette for å unngå "uendelige" gjentakende feilmeldinger på jobber i #team-arcgis-prod-alerts når jobbene kjøre successfullt neste gang.